### PR TITLE
PR: Downgrade Python container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 #.DS_Store
 .DS_Store
+
+# personal_use
+personal_use/

--- a/Django_app/config/settings.py
+++ b/Django_app/config/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Import secret env
@@ -80,12 +81,24 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
+# PostgreSQL DB setting
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
+        'HOST': os.environ.get('DB_HOST'),
+        'NAME': os.environ.get('DB_NAME'),
+        'USER': os.environ.get('DB_USER'),
+        'PASSWORD': os.environ.get('DB_PASS'),
     }
 }
+
+
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.sqlite3',
+#         'NAME': BASE_DIR / 'db.sqlite3',
+#     }
+# }
 
 
 # Password validation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11.0rc2-alpine3.16
+#FROM python:3.11.0rc2-alpine3.16
+FROM python:3.10.10-alpine3.17
 
 MAINTAINER FolaFlor
 LABEL maintainer="https://dpcalfola.tistory.com/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,22 @@ services:
       - ./Django_app:/Django_app
     command: >
       sh -c "python manage.py runserver 0.0.0.0:8000"
+    environment:
+      - DB_HOST=db_dev
+      - DB_NAME=fola_api_db_dev
+      - DB_USER=db_user_dev
+      - DB_PASS=asz;dukirgh2
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15rc1-alpine3.16
+    volumes:
+      - fola-api-db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=db_dev
+      - POSTGRES_USER=db_user_dev
+      - POSTGRES_PASSWORD=asz;dukirgh2
+
+volumes:
+  fola-api-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command: >
       sh -c "python manage.py runserver 0.0.0.0:8000"
     environment:
-      - DB_HOST=db_dev
+      - DB_HOST=db
       - DB_NAME=fola_api_db_dev
       - DB_USER=db_user_dev
       - DB_PASS=asz;dukirgh2
@@ -25,7 +25,7 @@ services:
     volumes:
       - fola-api-db-data:/var/lib/postgresql/data
     environment:
-      - POSTGRES_DB=db_dev
+      - POSTGRES_DB=fola_api_db_dev
       - POSTGRES_USER=db_user_dev
       - POSTGRES_PASSWORD=asz;dukirgh2
 

--- a/documents/frequentlyUsedCommands.md
+++ b/documents/frequentlyUsedCommands.md
@@ -6,7 +6,7 @@
 * Clear compose container and restart
     
     ```shell
-    docker-compose down && docker-compose build && docker-compose up
+    docker-compose down && docker-compose build --no-cache && docker-compose up
     ``` 
 
 * Test and Lint

--- a/study_documents/command_document/run_command/server_command.md
+++ b/study_documents/command_document/run_command/server_command.md
@@ -7,3 +7,10 @@
 ```shell
 docker-compose up
 ```
+
+
+
+### Clear compose container and restart
+```shell
+docker-compose down && docker-compose build --no-cache && docker-compose up
+```


### PR DESCRIPTION
Fix > Downgrade Python container

    * Downgrade Python container for stability
        python:3.11.0rc2-alpine3.16
        -> python:3.10.10-alpine3.17

        0rc2 means 0 release candidate 2,
        which is not a stable release


    * Need to change Postgres container version same reason
        Current version:
            postgres:15rc1-alpine3.16

        But, could not be sure data compatibility
        So for now, using current version for a while

        Postgres contain version should be changed someday, eventually
