### PR TITLE
Close issue of exposing env data

### DIFF
--- a/.github/workflows/CI_checks.yml
+++ b/.github/workflows/CI_checks.yml
@@ -14,8 +14,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Create env file
         run: |
           mkdir Django_app/config/env
@@ -26,7 +28,16 @@ jobs:
           echo "Success writing env data"
         env:
           DJANGO_ENV: ${{ secrets.DJANGO_ENV }}
+          POSTGRES_DB_NAME: ${{ secrets.CI_ENV.POSTGRES_DB_NAME }}
+          POSTGRES_DB_USER: ${{ secrets.CI_ENV.POSTGRES_DB_USER }}
+          POSTGRES_DB_PASSWORD: ${{ secrets.CI_ENV.POSTGRES_DB_PASSWORD }}
+          POSTGRES_DB_PORT: ${{ secrets.CI_ENV.POSTGRES_DB_PORT }}
+          SERVICE_PORT: ${{ secrets.CI_ENV.SERVICE_PORT }}
+          USERNAME: ${{ secrets.CI_ENV.USERNAME }}
+          TEST_VARIABLE: ${{ secrets.CI_ENV.TEST_VARIABLE }}
+
       - name: Test
         run: docker-compose run --rm app sh -c "sleep 7; python manage.py wait_for_db && python manage.py test"
+
       - name: Lint
         run: docker-compose run --rm app sh -c "flake8"

--- a/.github/workflows/CI_checks.yml
+++ b/.github/workflows/CI_checks.yml
@@ -28,13 +28,13 @@ jobs:
           echo "Success writing env data"
         env:
           DJANGO_ENV: ${{ secrets.DJANGO_ENV }}
-          POSTGRES_DB_NAME: ${{ secrets.CI_ENV.POSTGRES_DB_NAME }}
-          POSTGRES_DB_USER: ${{ secrets.CI_ENV.POSTGRES_DB_USER }}
-          POSTGRES_DB_PASSWORD: ${{ secrets.CI_ENV.POSTGRES_DB_PASSWORD }}
-          POSTGRES_DB_PORT: ${{ secrets.CI_ENV.POSTGRES_DB_PORT }}
-          SERVICE_PORT: ${{ secrets.CI_ENV.SERVICE_PORT }}
-          USERNAME: ${{ secrets.CI_ENV.USERNAME }}
-          TEST_VARIABLE: ${{ secrets.CI_ENV.TEST_VARIABLE }}
+          POSTGRES_DB_NAME: ${{ secrets.POSTGRES_DB_NAME }}
+          POSTGRES_DB_USER: ${{ secrets.POSTGRES_DB_USER }}
+          POSTGRES_DB_PASSWORD: ${{ secrets.POSTGRES_DB_PASSWORD }}
+          POSTGRES_DB_PORT: ${{ secrets.POSTGRES_DB_PORT }}
+          SERVICE_PORT: ${{ secrets.SERVICE_PORT }}
+          USERNAME: ${{ secrets.USERNAME }}
+          TEST_VARIABLE: ${{ secrets.TEST_VARIABLE }}
 
       - name: Test
         run: docker-compose run --rm app sh -c "sleep 7; python manage.py wait_for_db && python manage.py test"

--- a/.github/workflows/CI_checks.yml
+++ b/.github/workflows/CI_checks.yml
@@ -18,17 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Create CI env file
-        run: |
-          touch .env
-          echo "Success making empty CI env file"
-          echo ${CI_ENV} >> .env
-          echo "Success writing env data"
-          pwd
-          ls -la
-        env:
-          CI_ENV: ${{ secrets.CI_ENV }}
-
       - name: Create Django env file
         run: |
           mkdir Django_app/config/env
@@ -42,6 +31,14 @@ jobs:
 
       - name: Test
         run: docker-compose run --rm app sh -c "sleep 7; python manage.py wait_for_db && python manage.py test"
+        env:
+            POSTGRES_DB_NAME: fake_postgres_name
+            POSTGRES_DB_USER: fake_postgres_user
+            POSTGRES_DB_PASSWORD: fake_postgres_password
+            POSTGRES_DB_PORT: 5432
+            SERVICE_PORT: 8000
+            USERNAME: fake_username
+            TEST_VARIABLE: env_data_loaded
 
       - name: Lint
         run: docker-compose run --rm app sh -c "flake8"

--- a/.github/workflows/CI_checks.yml
+++ b/.github/workflows/CI_checks.yml
@@ -8,6 +8,14 @@ jobs:
   test:
     name: Test and Lint
     runs-on: ubuntu-22.04
+    env:
+      POSTGRES_DB_NAME: fake_postgres_name
+      POSTGRES_DB_USER: fake_postgres_user
+      POSTGRES_DB_PASSWORD: fake_postgres_password
+      POSTGRES_DB_PORT: 5432
+      SERVICE_PORT: 8000
+      USERNAME: fake_username
+      TEST_VARIABLE: env_data_loaded
     steps:
       - name: Login to Dockerhub
         uses: docker/login-action@v2
@@ -31,14 +39,6 @@ jobs:
 
       - name: Test
         run: docker-compose run --rm app sh -c "sleep 7; python manage.py wait_for_db && python manage.py test"
-        env:
-            POSTGRES_DB_NAME: fake_postgres_name
-            POSTGRES_DB_USER: fake_postgres_user
-            POSTGRES_DB_PASSWORD: fake_postgres_password
-            POSTGRES_DB_PORT: 5432
-            SERVICE_PORT: 8000
-            USERNAME: fake_username
-            TEST_VARIABLE: env_data_loaded
 
       - name: Lint
         run: docker-compose run --rm app sh -c "flake8"

--- a/.github/workflows/CI_checks.yml
+++ b/.github/workflows/CI_checks.yml
@@ -18,23 +18,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Create env file
+      - name: Create CI env file
         run: |
-          mkdir Django_app/config/env
-          echo "Success making env directory"
-          touch Django_app/config/env/secret_env.py
-          echo "Success making empty env file"
-          echo ${DJANGO_ENV} >> Django_app/config/env/secret_env.py
+          touch .env
+          echo "Success making empty CI env file"
+          echo ${CI_ENV} >> .env
           echo "Success writing env data"
         env:
+          CI_ENV: ${{ secrets.CI_ENV }}
+
+      - name: Create Django env file
+        run: |
+          mkdir Django_app/config/env
+          echo "Success making Django env directory"
+          touch Django_app/config/env/secret_env.py
+          echo "Success making empty Django env file"
+          echo ${DJANGO_ENV} >> Django_app/config/env/secret_env.py
+          echo "Success writing Django env data"
+        env:
           DJANGO_ENV: ${{ secrets.DJANGO_ENV }}
-          POSTGRES_DB_NAME: ${{ secrets.POSTGRES_DB_NAME }}
-          POSTGRES_DB_USER: ${{ secrets.POSTGRES_DB_USER }}
-          POSTGRES_DB_PASSWORD: ${{ secrets.POSTGRES_DB_PASSWORD }}
-          POSTGRES_DB_PORT: ${{ secrets.POSTGRES_DB_PORT }}
-          SERVICE_PORT: ${{ secrets.SERVICE_PORT }}
-          USERNAME: ${{ secrets.USERNAME }}
-          TEST_VARIABLE: ${{ secrets.TEST_VARIABLE }}
 
       - name: Test
         run: docker-compose run --rm app sh -c "sleep 7; python manage.py wait_for_db && python manage.py test"

--- a/.github/workflows/CI_checks.yml
+++ b/.github/workflows/CI_checks.yml
@@ -24,6 +24,8 @@ jobs:
           echo "Success making empty CI env file"
           echo ${CI_ENV} >> .env
           echo "Success writing env data"
+          pwd
+          ls -la
         env:
           CI_ENV: ${{ secrets.CI_ENV }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /Django_app
 EXPOSE 48007
 
 ARG DEV=false
+ARG USERNAME
+
 RUN python -m venv /py && \
     /py/bin/pip install --upgrade pip && \
     # Installation psycopg2 dependency applications
@@ -31,8 +33,8 @@ RUN python -m venv /py && \
     adduser \
         --disabled-password \
         --no-create-home \
-        Django-user
+        $USERNAME
 
 ENV PATH="/py/bin:$PATH"
 
-USER Django-user
+USER ${USERNAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,28 +6,32 @@ services:
       context: .
       args:
         - DEV=true
+        - USERNAME=${USERNAME}
     ports:
-      - "48007:8000"
+      - "${SERVICE_PORT}:8000"
     volumes:
       - ./Django_app:/Django_app
     command: >
-      sh -c "python manage.py runserver 0.0.0.0:8000"
+      sh -c "echo ${TEST_VARIABLE} && python manage.py runserver 0.0.0.0:8000"
     environment:
       - DB_HOST=db
-      - DB_NAME=fola_api_db_dev
-      - DB_USER=db_user_dev
-      - DB_PASS=asz;dukirgh2
+      - DB_NAME=${POSTGRES_DB_NAME}
+      - DB_USER=${POSTGRES_DB_USER}
+      - DB_PASS=${POSTGRES_DB_PASSWORD}
     depends_on:
       - db
 
   db:
     image: postgres:15.2-alpine3.17
+    ports:
+      - "${POSTGRES_DB_PORT}:5432"
     volumes:
       - fola-api-db-data:/var/lib/postgresql/data
     environment:
-      - POSTGRES_DB=fola_api_db_dev
-      - POSTGRES_USER=db_user_dev
-      - POSTGRES_PASSWORD=asz;dukirgh2
+      - POSTGRES_DB=${POSTGRES_DB_NAME}
+      - POSTGRES_USER=${POSTGRES_DB_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_DB_PASSWORD}
+
 
 volumes:
   fola-api-db-data:

--- a/documents/Develop_task/env_management.txt
+++ b/documents/Develop_task/env_management.txt
@@ -10,3 +10,11 @@ Issue #1 - Exposed DB info on docker-compose.yml
     2.1 add ${VARIABLE}
 3. on Dockerfile
     3.1 add ${VARIABLE} and ARG VARIABLE
+
+
+
+
+Issue #2 - CI need env data but hided
+
+1. Set fake env data on CI setting file
+    It should be runs-on level

--- a/documents/Develop_task/env_management.txt
+++ b/documents/Develop_task/env_management.txt
@@ -1,0 +1,12 @@
+< Hide DB info >
+
+
+
+Issue #1 - Exposed DB info on docker-compose.yml
+
+1. make .env file and add info data
+    1.1 VARIABLE=VALUE
+2. on docker-compose.yml
+    2.1 add ${VARIABLE}
+3. on Dockerfile
+    3.1 add ${VARIABLE} and ARG VARIABLE


### PR DESCRIPTION
Close issue of exposing env data:

    * Problem:
        -The database and Dockerfile user information are currently exposed.
        - Although it works within the group of containers, this poses a potential problem.
    
    * Solution:
        - Change the exposed env data and expire it.
        - Hide the database and Dockerfile user information in a .env file.
    
    * Fake env data for CI test:
        - Set fake env data on the CI server (in the runs-on level).
        - This affects all steps in the CI test.
        - The CI test works well with fake env data.